### PR TITLE
Fix minor typos in Spanish translation

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -30,7 +30,7 @@
 	<string name="image_detail_size">Tamaño de archivo: %1$s</string>
 	<string name="image_detail_modified">Modificado: %1$s</string>
     
-	<string name="toast_no_files">No archivos que mostrar</string>
+	<string name="toast_no_files">Sin archivos que mostrar</string>
 
 	<string name="long_loading_warning">%1$s está tardando para cargar.</string>
 	<string name="long_loading_skipping">%1$s está tardando para cargar. Omitir.</string>
@@ -79,12 +79,12 @@
 	</string>
     
 	<string name="pref_title_remember_location">Comenzar en la última ubicación</string>
-	<string name="pref_description_remember_location">Al abrir, &appname; comenzarará en la 
-        ubicación donde la última reproducción de diapositivas fue usada.
+	<string name="pref_description_remember_location">Al abrir, &appname; comenzará en la 
+        ubicación donde la última reproducción de diapositivas fue iniciada.
     </string>
     
 	<string name="pref_title_auto_start">Comenzar automáticamente</string>
-	<string name="pref_description_auto_start">Al abrir, &appname; comenzarará una reproducción
+	<string name="pref_description_auto_start">Al abrir, &appname; comenzará una reproducción
         de diapositivas desde la última imagen que fue mostrada.
     </string>
         
@@ -95,7 +95,7 @@
 		defecto dado que puede tener un impacto negativo en el rendimiento.
 	</string>
     
-	<string name="pref_title_enable_gif_support">Activar suporte de GIF</string>
+	<string name="pref_title_enable_gif_support">Activar soporte de GIF</string>
 	<string name="pref_description_enable_gif_support">Automáticamente reproducir GIFs
         al mostrarlos. Requiere Glide para la carga de imágenes.
     </string>    
@@ -115,18 +115,18 @@
 	<string name="pref_title_image_strategy">Usar Glide para cargar imágenes</string>
 	<string name="pref_description_image_strategy">Usar Glide para cargar imágenes. Glide tiene soporte para
         otras funciones como precarga y soporte de GIF. Desactivar esta opción activará la antigua estrategia
-        de carga de imágenes. Ésta función tiene mejor rendimiento en algunos dispositivos.
+        de carga de imágenes. Esta función tiene mejor rendimiento en algunos dispositivos.
     </string>
     
 	<string name="pref_title_preload_images">Precargar imágenes</string>
-	<string name="pref_description_preload_images">Cargar la siguiente imagen durante la actual diaspositiva.
+	<string name="pref_description_preload_images">Cargar la siguiente imagen durante la actual diapositiva.
         Desactivar esta función puede incrementar el rendimiento en algunos dispositivos. Requiere Glide para la 
         carga de imágenes.
     </string>
         
 	<string name="pref_title_skip_long_load">Omitir imágenes que tardan en cargar</string>
 	<string name="pref_description_skip_long_load">Omitir imágenes que toman mucho tiempo en cargar durante
-        la reproducción de diaspositivas. Una notificación se mostrará cuando esto ocurra.
+        la reproducción de diapositivas. Una notificación se mostrará cuando esto ocurra.
     </string>
 
 	<string name="pref_title_image_details">Mostrar detalles de la imagen</string>


### PR DESCRIPTION
@uzluisf did all of the heavy lifting, I just fixed some minor typos and evened out the wording.