### PR TITLE
Allow refreshing the folder every time around

### DIFF
--- a/app/src/main/java/link/standen/michael/slideshow/ImageActivity.java
+++ b/app/src/main/java/link/standen/michael/slideshow/ImageActivity.java
@@ -58,6 +58,7 @@ public class ImageActivity extends BaseActivity implements ImageStrategy.ImageSt
 	private static boolean STOP_ON_COMPLETE;
 	private static boolean REVERSE_ORDER;
 	private static boolean RANDOM_ORDER;
+	private static boolean REFRESH_FOLDER;
 	private static int SLIDESHOW_DELAY;
 	private static boolean IMAGE_DETAILS;
 	private static boolean IMAGE_DETAILS_DURING;
@@ -435,6 +436,8 @@ public class ImageActivity extends BaseActivity implements ImageStrategy.ImageSt
 		Log.d(TAG, String.format("REVERSE_ORDER: %b", REVERSE_ORDER));
 		RANDOM_ORDER = preferences.getBoolean("random_order", false);
 		Log.d(TAG, String.format("RANDOM_ORDER: %b", RANDOM_ORDER));
+		REFRESH_FOLDER = preferences.getBoolean("refresh_folder", false);
+		Log.d(TAG, String.format("REFRESH_FOLDER: %b", REFRESH_FOLDER));
 		IMAGE_DETAILS = preferences.getBoolean("image_details", false);
 		Log.d(TAG, String.format("IMAGE_DETAILS: %b", IMAGE_DETAILS));
 		IMAGE_DETAILS_DURING = preferences.getBoolean("image_details_during", false);
@@ -478,6 +481,13 @@ public class ImageActivity extends BaseActivity implements ImageStrategy.ImageSt
 
 		int current = imagePosition;
 		int newPosition = imagePosition;
+		if (REFRESH_FOLDER && newPosition == 0) { // Time to reload, easy base case
+			fileList = new FileItemHelper(this).getFileList(currentPath, false, getIntent().getStringExtra("imagePath") == null);
+			if (RANDOM_ORDER){
+				Collections.shuffle(fileList);
+			}
+		}
+
 		do {
 			newPosition += forwards ? 1 : -1;
 			if (newPosition < 0){

--- a/app/src/main/java/link/standen/michael/slideshow/SettingsActivity.java
+++ b/app/src/main/java/link/standen/michael/slideshow/SettingsActivity.java
@@ -108,6 +108,8 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
 			addPreferencesFromResource(R.xml.preferences);
 			setHasOptionsMenu(true);
 
+			final SwitchPreference reloadFolderPref = (SwitchPreference)findPreference("reload_folder");
+
 			final SwitchPreference reverseOrderPref = (SwitchPreference)findPreference("reverse_order");
 			final SwitchPreference randomOrderPref = (SwitchPreference)findPreference("random_order");
 			// Enabling reverse disables random

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -169,6 +169,10 @@
 		order.
 	</string>
 
+	<string name="pref_title_refresh_folder">Refresh Folder</string>
+	<string name="pref_description_refresh_folder">Refresh the folder every time through the show.
+	</string>
+
 	<string name="pref_title_random_order">Random order</string>
 	<string name="pref_description_random_order">Display the images in the slideshow in a random
 		order.

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -111,6 +111,12 @@
 		android:title="@string/pref_title_random_order"/>
 
 	<SwitchPreference
+		android:defaultValue="false"
+		android:key="refresh_folder"
+		android:summary="@string/pref_description_refresh_folder"
+		android:title="@string/pref_title_refresh_folder"/>
+
+	<SwitchPreference
 		android:defaultValue="true"
 		android:key="delete_warning"
 		android:summary="@string/pref_description_delete_warning"


### PR DESCRIPTION
This is for the usecase where, for example, you use a file
synchronization tool or manual uploads for a photo slideshow. Simply
put, this patch reloads the file list every time the slideshow comes
to an end, allowing new random orders every time through and new files
being recognized.

Closes #133.