### PR TITLE
Add Ukrainian translation

### DIFF
--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE resources [
+    <!ENTITY appname "Slideshow">
+    <!ENTITY author "Michael Standen">
+    ]>
+
+<resources>
+    <string name="app_name">&appname;</string>
+    <string name="action_settings">Налаштування</string>
+    <string name="action_credits">Про застосунок</string>
+    <string name="action_change_log">Останні зміни</string>
+    <string name="action_controls">Керування</string>
+
+    <!-- List -->
+    <string name="inaccessible">(недоступно)</string>
+    <string name="go_home_folder">Застрягли? Натисніть щоб повернутися додому</string>
+    <string name="play_folder">Запустити Слайдшоу звідси</string>
+
+    <!-- Slideshow -->
+    <string name="title_activity_image">&appname;</string>
+
+    <string name="delete_button">Видалити</string>
+    <string name="delete_dialog_title">Видалити зображення</string>
+    <string name="delete_dialog_message">Ви впевнені?</string>
+    <string name="image_deleted">Зображення видалено</string>
+    <string name="image_not_deleted">Не вдалося видалити зображення</string>
+
+    <string name="share_button">Поділитися</string>
+    <string name="share_via">Поділитися з &#8230;</string>
+
+    <string name="image_detail_dimensions">Розмірності: %1$dx%2$d</string>
+    <string name="image_detail_size">Розмір файла: %1$s</string>
+    <string name="image_detail_modified">Модифікован: %1$s</string>
+    <string name="toast_error_loading_image">Виникла помилка під час завантаження зображення</string>
+    <string name="long_loading_warning">%1$s потребує багато часу для завантаження.</string>
+    <string name="long_loading_skipping">%1$s потребує багато часу для завантаження. Пропускаю.</string>
+    <string name="long_loading_skip_action">Пропустити</string>
+    <string name="toast_no_files">Нема файлів для показу</string>
+
+    <!-- Controls -->
+    <string name="controls_title">&appname;Керування</string>
+    <string name="controls_content1">Є декілька схованих керувань під час перегляду слайдшоу.</string>
+    <string name="controls_content2">*Змахніть вліво / вправо* щоб перейти до наступного / попереднього зображення.</string>
+    <string name="controls_content3">*Один дотик* щоб почати / зупинити слайдшоу.</string>
+    <string name="controls_content5">*Подвійний дотик* щоб поставити слайдшоу на паузу без показу панелі з деталями.</string>
+    <string name="controls_content4">*Довгий дотик під час слайдшоу* щоб виключити ввод від користувача. Це буде у пригоді коли Ви не хочете щоб бабуся випадково зупинила слайдшоу під час прибирання пристрою від пилу.</string>
+
+    <!-- Image descriptions -->
+    <string name="image_description">Зображення</string>
+    <string name="logo_description">Логотип</string>
+
+    <!-- Credits -->
+    <string name="title_activity_credits">Про застосунок</string>
+    <string name="credits_creator">Створено <a href="https://michael.standen.link">&author;</a></string>
+    <string name="credits_content1">&appname; це простий застосунок для перегляду зображень на Вашому телефоні</string>
+    <string name="credits_content2">Без будь-яких наворотів, цей застосунок - найпростіший застосунок для показу слайдів в магазині.</string>
+    <string name="credits_content3">Ви можете переглянути початковий код застосунку, повідомити про проблему або запропонувати нові функції на <a href="https://github.com/Screaminghawk/android-slideshow">Github</a>.</string>
+    <string name="credits_content4">Це застосунок з відкритим початковим кодом і він повністью безплатний; ліцензований у відповідності з <a href="https://tldrlegal.com/license/mit-license">MIT license</a>.</string>
+    <string name="credits_content5">Подяки  <a href="https://github.com/psyanite">Yan Tsui</a> за тестування та дизайн іконки.</string>
+    <string name="credits_content6">Цей переклад &appname; надан Вам автором
+		<a href="https://github.com/JekRock">Євген Бадьров</a>
+	</string>
+    <!-- Settings -->
+
+    <string name="title_activity_settings">Налаштування</string>
+
+    <string name="pref_title_show_hidden_files">Показати приховані файли</string>
+    <string name="pref_description_show_hidden_files">Відобразити файли приховані іншими файловими менеджерами.</string>
+
+    <string name="pref_title_show_thumbnails">Показати миніатюри</string>
+    <string name="pref_description_show_thumbnails">Відображає зменшені зображення. Відключення цього режиму приведе до збільшення продуктивності, але Ви не зможете побачити, які файли є зображеннями, а які ні.</string>
+
+    <string name="pref_title_play_from_here">Активувати кнопку "Запустити звідси"</string>
+    <string name="pref_description_play_from_here">Кнопка "Запустити звідси" з\'явиться у списку файлів
+	    та дозволить Вам почати Слайдшоу з поточної директорії, включаючи всі піддиректорії.
+		За замовченням цю властивість вимкнено, так як вона може негативно відобразитися на продуктивності
+    </string>
+
+    <string name="pref_title_use_device_root">Використовувати корінь пристрою</string>
+    <string name="pref_description_use_device_root">Увімкнути навигацію до кореневого каталогу пристрою. Це дозволить отримати доступ до файлів в будь-якому місці пристрою, включаючи підключені сховища, такі як SD-картки. Примітка. Може знадобитися пристрій з root доступом.</string>
+
+    <string name="pref_title_slide_delay">Пауза слайдів</string>
+    <string name="pref_description_slide_delay">Натисніть щоб змінити кількість секунд напротязі яких зображення буде показано перед зміною зображення.</string>
+
+    <string name="pref_title_image_details">Відобразити інформацію зображення</string>
+    <string name="pref_description_image_details">Відобразити інформацію зображення під час слайд-шоу.</string>
+
+    <string name="pref_title_stop_on_complete">Зупинити по завершенню</string>
+    <string name="pref_description_stop_on_complete">Зупинити слайд-шоу після того як всі зображення будуть показани.</string>
+
+    <string name="pref_title_reverse_order">Зворотня послідовність</string>
+    <string name="pref_description_reverse_order">Відобразити зображення під час слайд-шоу в зворотній послідовності.</string>
+
+    <string name="pref_title_refresh_folder">Оновити директорію</string>
+    <string name="pref_description_refresh_folder">Оновити директорію кожного разу під час показу.
+	</string>
+
+    <string name="pref_title_random_order">Випадкова послідовність</string>
+    <string name="pref_description_random_order">Відобразити зображення під час слайд-шоу в випадковій послідовності.</string>
+
+    <string name="pref_description_auto_start">При запуску &appname; почне слайдшоу
+		з останнього показаного зображення.
+	</string>
+    <string name="pref_title_enable_gif_support">Включити підтримку GIF</string>
+
+    <string name="pref_description_preload_images">Завантажувати наступне зображення поки знаходимося на поточному слайді
+		Вимкненя цієї опції може збільшити продуктивність на деяких пристроях.
+	</string>
+    <string name="pref_description_remember_location">При запуску &appname; запуститься на місці,
+		де слайдшоу було останній раз використано.
+	</string>
+
+    <string name="pref_description_skip_long_load">Пропустити зображення, занадто довго завантажуються
+		під час слайдшоу. Коли це відбудеться, буде показано повідомлення.
+	</string>
+    <string name="pref_title_auto_start">Запускати автоматично</string>
+
+    <string name="pref_title_preload_images">Предзавантаження зображень</string>
+    <string name="pref_title_remember_location">Запускати в останньому місцезнаходженні</string>
+
+    <string name="pref_title_skip_long_load">Пропустити зображення, які довго завантажуються</string>
+    <string name="pref_description_enable_gif_support">Автоматично запускати GIF при показі.
+	</string>
+    <string name="action_picture_in_picture">Зображення у зображенні</string>
+    <string name="no_picture_in_picture">Опція зображення у зображенні недоступна для вашого пристрою</string>
+    <string name="toast_paused">Призупинено</string>
+    <string name="toast_resumed">Відновлено</string>
+    <string name="toast_input_blocked">Ввод заблоковано. Довгий дотик щоб увімкнути</string>
+    <string name="toast_input_allowed">Ввод увімкнено</string>
+    <string name="pref_title_image_strategy">Використовувати Glide для завантаження зображень</string>
+    <string name="pref_description_image_strategy">Використовувати Glide для завантаження зображень. Ця бібліотека має і інші функції, такі як предзавантаження та підтримка GIF. Якщо Glide будет вимкнено, замість нього буде використано стару стратегію завантаження зображень. Іноді це працює швидше на деяких пристроях.</string>
+    <string name="pref_title_auto_rotate_dimen">Автоматично перевертати залежно від розміру зображення</string>
+    <string name="pref_description_auto_rotate_dimen">Автоматично перевертати зображення у пейзажний режим, якщо ширина зображення більше, ніж його висота</string>
+    <string name="pref_title_delete_warning">Попереджувати перед видаленням</string>
+    <string name="pref_description_delete_warning">Показати попередження перед видаленням зображення. Вимикайте на свій страх та ризик</string>
+    <string name="pref_title_image_details_during">Показувати властивості зображення під час слайдшоу</string>
+    <string name="pref_description_image_details_during">Перекривати властивості зображення під час показу слайдшоу</string>
+
+</resources>


### PR DESCRIPTION
Add full Ukrainian translation.
Translations editor in the Android studio points to the "credits_creator" with the "Invalid XML" error in the Ukrainian translation. But it's the same as original except one word.